### PR TITLE
added destructuring to import function

### DIFF
--- a/components/canvas/SchemaIDE.js
+++ b/components/canvas/SchemaIDE.js
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useStore, useStoreState } from 'react-flow-renderer';
 
-import generateAllTypes from '../../converters/typeDefs.js';
+import { generateAllTypes } from '../../converters/typeDefs.js';
 
 const SchemaIDE = (props) => {
 


### PR DESCRIPTION
We changed the way we're exporting generateAllTypes in order to add testing so I added object destructuring in SchemaIDE.js to properly import that function.